### PR TITLE
ci: run typecheck, unit tests and a build on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+# Typecheck, unit tests and a build on every PR and push to main. The e2e suite
+# stays out: it needs a built app and a display, so it gets its own workflow.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+# The two triggers can never collide: `github.ref` is `refs/pull/<n>/merge` for
+# pull_request but `refs/heads/main` for push, so a merge never cancels a PR run
+# still in flight. `github.workflow` is in the key — groups are repository-wide.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # One runner is enough — nothing here is platform-specific.
+  check:
+    runs-on: ubuntu-latest
+    # A stalled Electron download would otherwise sit on the 6-hour default.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      # 20 to match the runtime release.yml builds the installers on.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      # Keeps postinstall (electron-rebuild for better-sqlite3) rather than
+      # --ignore-scripts: a broken native build should fail here, not at release.
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Unit tests
+        run: npm run test:run
+
+      # tsc and the bundler resolve imports differently — a broken alias or JSON
+      # import fails only here. Runs without secrets (integration goes dormant).
+      - name: Build
+        run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,30 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     steps:
+      # Only here to read package.json for the version guard below. Nothing in
+      # this job runs git, so the contents: write token need not land on disk.
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # The tag decides which release-notes file finalize picks up; package.json
+      # decides the version electron-builder stamps into the installers. Nothing
+      # tied the two together, so `git tag v1.9.1` on a 1.9.0 manifest used to
+      # build and publish silently under the wrong name. Fail before the draft
+      # exists, so a mismatch leaves nothing to clean up.
+      #
+      # `node` is preinstalled on ubuntu-latest, so this needs no setup-node.
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          TAG_VERSION="${TAG#v}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag ${TAG} does not match package.json version ${PKG_VERSION}. Bump package.json to ${TAG_VERSION} (and add .github/release-notes/${TAG_VERSION}.md), or delete the tag and retag the right commit."
+            exit 1
+          fi
+          echo "Tag ${TAG} matches package.json version ${PKG_VERSION}."
+
       - name: Create draft release if it does not exist
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

There is no CI. The two existing workflows fire on a release tag and on manual
dispatch, so nothing runs `npm run typecheck` or `npm run test:run` — even though the
pull-request template asks contributors to confirm both pass. My previous PR (#6) arrived
with zero automated signal, which is what prompted this.

Adds **`.github/workflows/ci.yml`**: one ubuntu job on `pull_request` and pushes to `main`,
running typecheck → unit tests → `npm run build`.

The build step earns its place because tsc and the bundler resolve imports differently: a
broken path alias or JSON import passes the typecheck and fails only when electron-vite
runs. Cheap checks run first.

`pull_request` (not `pull_request_target`) with `permissions: contents: read`, because
nothing here needs secrets — verified: `npm run build` succeeds with `MAIN_VITE_FS_*`
unset, producing all three bundles and baking in no AppKey-shaped literal. That is exactly
the dormant-integration path release.yml already documents, so fork PRs get the same checks
as branch pushes.

The e2e suite is deliberately excluded — it builds the app and needs a display, so it wants
its own workflow rather than a place on every push.

### Second change: a tag/manifest guard in `release.yml`

The tag chooses the release-notes file; `package.json` decides the version electron-builder
stamps into the installers. Nothing connected them, so `git tag v1.9.1` on a `1.9.0`
manifest would have built and published silently under the wrong name.

The check runs **before** the draft release is created, so a mismatch leaves nothing to
clean up. Reading `package.json` needs a checkout, which `prepare` did not have; it is added
with `persist-credentials: false`, since this job runs no git and the workflow's
`contents: write` token has no reason to land in `.git/config`.

Confirmed a no-op on history: all **39** existing `v*` tags match their `package.json`
version, so this cannot fire on a release that would previously have succeeded.

## Related issue

Closes #8 — opened first per CONTRIBUTING, with the two open questions (one PR or two, and
whether a single runner is the right call) spelled out there.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor / cleanup
- [ ] 📝 Docs / translations
- [x] 🔧 Build / tooling

## How was this tested?

- Both files parse under js-yaml.
- The full chain was run locally on a pristine `main` checkout with `MAIN_VITE_FS_*`
  explicitly unset: `npm ci` → `npm run typecheck` (exit 0) → `npm run test:run`
  (12 files / 87 tests) → `npm run build` (exit 0, all three bundles produced). So CI is
  green on `main` from the first run rather than landing red.
- The guard's shell body was extracted from the YAML and executed under `bash -e`:
  `v1.9.0` → passes; `v1.9.1` → fails with an `::error::` annotation naming both versions
  and the fix. Edge cases checked (empty ref, pre-release version, tag without the `v`)
  fail safe.
- Job dependencies re-read to confirm `prepare` failing halts everything: `build` and
  `web-demo` both `needs: prepare`, and `finalize` needs `[build, web-demo]`.
- `ubuntu-latest` compatibility of `npm ci` + `electron-rebuild` is already demonstrated by
  the published Linux assets of v1.9.0.

**Not verified:** the `release.yml` change cannot be exercised by a PR — it only runs on a
tag push, so it lands on trust in the shell above. If you would rather split it out and take
the CI workflow alone, say so and I will.

## Deliberately left alone

Found while reading the workflows, all pre-existing, none touched here to keep the diff
reviewable — happy to file any of them separately:

- Actions are pinned to mutable major tags (`@v4`) rather than SHAs, in a workflow with
  `contents: write` and access to `FS_CLIENT_ID`.
- `release.yml` has no `concurrency` group.
- A pre-release tag would still get `--latest`.
- A stray draft release survives if a platform build fails.
- No dependabot or CodeQL config.
- The `web-demo` comment still says `treemonk.eu/demo`; serving moved to `/webapp` in
  5598774 (the historical asset name is intentional, per the comment itself).

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run test:run` passes
- [x] No cloud calls / telemetry added — the app stays local-first and private
- [x] Docs/translations updated if needed
- [x] I agree my contribution is licensed under the project's [PolyForm Noncommercial License 1.0.0](../LICENSE)
