### PR TITLE
Add country-based FanChart visualization

### DIFF
--- a/src/main/db/tree.ts
+++ b/src/main/db/tree.ts
@@ -1,6 +1,7 @@
-import { Families, People } from './repo'
+import { Families, People, Places, type PlaceRow } from './repo'
 import { documentCountsByPerson } from './documentCounts'
 import type { Family, Person, TreeNodeDatum } from '@shared/types'
+import { canonicalCountryName, knownCountryAlias, lastPlacePart } from '@shared/placeNormalize'
 
 export type TreeMode = 'ancestors' | 'descendants'
 
@@ -48,6 +49,42 @@ export function buildTree(rootId?: string, mode: TreeMode = 'ancestors'): TreeNo
   if (people.length === 0) return []
   const byId = new Map<string, Person>(people.map((p) => [p.id, p]))
   const docCounts = documentCountsByPerson()
+  const placeRows = new Map<string, PlaceRow>(Places.list().map((p) => [p.name, p]))
+
+  const placeRow = (name: string | null | undefined): PlaceRow | null => {
+    const key = name?.trim()
+    return key ? placeRows.get(key) ?? null : null
+  }
+
+  const canonicalName = (name: string | null | undefined): string | null => {
+    const key = name?.trim()
+    if (!key) return null
+    const row = placeRow(key)
+    return row?.canonical?.trim() || row?.name || key
+  }
+
+  const canonicalCountry = (place: string | null | undefined): string | null => {
+    const statedCountry = knownCountryAlias(lastPlacePart(place))
+    if (statedCountry) return statedCountry
+
+    const canonical = canonicalName(place)
+    if (!canonical) return null
+
+    let cur = placeRow(canonical) ?? placeRow(place)
+    const seen = new Set<string>()
+    while (cur && !seen.has(cur.name) && seen.size < 12) {
+      seen.add(cur.name)
+      if ((cur.place_type ?? '').toLowerCase() === 'country') {
+        return canonicalCountryName(canonicalName(cur.name) ?? cur.name)
+      }
+      cur = cur.parent_name ? placeRow(cur.parent_name) : null
+    }
+
+    return canonicalCountryName(lastPlacePart(canonical) ?? lastPlacePart(place))
+  }
+
+  const countryFor = (person: Person): string | null =>
+    canonicalCountry(person.birthPlace) ?? canonicalCountry(person.deathPlace)
 
   // Indexes.
   const parentFamilies = new Map<string, Family[]>() // person -> families where parent
@@ -94,6 +131,9 @@ export function buildTree(rootId?: string, mode: TreeMode = 'ancestors'): TreeNo
       sex: person.sex,
       birthYear: yearOf(person.birthDate),
       deathYear: yearOf(person.deathDate),
+      birthPlace: person.birthPlace,
+      deathPlace: person.deathPlace,
+      country: countryFor(person),
       attributes: attributesFor(person, docCounts),
       children: parents.length ? parents : undefined
     }
@@ -123,6 +163,9 @@ export function buildTree(rootId?: string, mode: TreeMode = 'ancestors'): TreeNo
       sex: person.sex,
       birthYear: yearOf(person.birthDate),
       deathYear: yearOf(person.deathDate),
+      birthPlace: person.birthPlace,
+      deathPlace: person.deathPlace,
+      country: countryFor(person),
       attributes: attributesFor(person, docCounts, { spouse: spouses.join(', ') }),
       children: children.length ? children : undefined
     }

--- a/src/renderer/src/components/tree/ExportTreeDialog.tsx
+++ b/src/renderer/src/components/tree/ExportTreeDialog.tsx
@@ -191,6 +191,7 @@ export function ExportTreeDialog({
     // Fan label font (a bundled, self-hosted face). 'system' leaves the poster
     // default in place; anything else overrides the fan text + embeds the woff2.
     fanFontFamily: ped.fanFont === 'system' ? undefined : chartFontFamily(ped.fanFont),
+    fanColorMode: ped.fanColorMode,
     fanFontFaceCss
   })
 

--- a/src/renderer/src/components/tree/FanChart.tsx
+++ b/src/renderer/src/components/tree/FanChart.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useTranslation } from 'react-i18next'
 import type { TreeNodeDatum } from '@shared/types'
+import { canonicalCountryName } from '@shared/placeNormalize'
 import type { FanColorMode, FanSweep } from '@/store/usePedigreeSettings'
 import { formatName } from '@/lib/utils'
 import { chartFontFamily, ensureChartFont } from '@/lib/chartFonts'
@@ -66,6 +67,24 @@ function alphaFor(gen: number): number {
 }
 
 const GEN_HUES = [212, 250, 286, 330, 8, 40, 158, 186]
+const COUNTRY_HUES = [168, 36, 212, 334, 78, 266, 16, 196, 118, 308, 46, 226, 356, 144]
+
+function hashText(text: string): number {
+  let h = 0
+  for (let i = 0; i < text.length; i++) h = (h * 31 + text.charCodeAt(i)) >>> 0
+  return h
+}
+
+function countryFromPlace(place: string | null | undefined): string | null {
+  const raw = place?.trim()
+  if (!raw) return null
+  const parts = raw.split(',').map((p) => p.trim()).filter(Boolean)
+  return canonicalCountryName(parts.at(-1))
+}
+
+function countryOf(datum: TreeNodeDatum): string | null {
+  return datum.country ?? countryFromPlace(datum.birthPlace) ?? countryFromPlace(datum.deathPlace)
+}
 
 function fillFor(
   datum: TreeNodeDatum,
@@ -77,6 +96,12 @@ function fillFor(
   if (mode === 'generation') {
     const h = GEN_HUES[(gen - 1) % GEN_HUES.length]
     return `hsl(${h} 64% 56% / ${a})`
+  }
+  if (mode === 'country') {
+    const country = countryOf(datum)
+    if (!country) return `rgba(148,163,184,${Math.max(0.12, a * 0.72)})`
+    const h = COUNTRY_HUES[hashText(country.toLowerCase()) % COUNTRY_HUES.length]
+    return `hsl(${h} 68% 50% / ${a})`
   }
   if (mode === 'mono') return `rgba(${accent[0]},${accent[1]},${accent[2]},${a})`
   const rgb =
@@ -690,7 +715,12 @@ function FanChartImpl({
           const canvas = canvasRef.current
           if (canvas) canvas.style.cursor = t ? 'pointer' : 'grab'
           if (t?.datum) {
-            setHover({ label: t.full, sub: t.years, mx: e.clientX, my: e.clientY })
+            setHover({
+              label: t.full,
+              sub: [t.years, countryOf(t.datum)].filter(Boolean).join(' · '),
+              mx: e.clientX,
+              my: e.clientY
+            })
           } else {
             setHover((h) => (h ? null : h))
           }

--- a/src/renderer/src/components/tree/FanOptions.tsx
+++ b/src/renderer/src/components/tree/FanOptions.tsx
@@ -9,7 +9,7 @@ import {
 import { CHART_FONTS, chartFontFamily, ensureChartFont, type FontCategory } from '@/lib/chartFonts'
 
 const SWEEPS: FanSweep[] = [360, 270, 180]
-const COLOR_MODES: FanColorMode[] = ['sex', 'generation', 'mono']
+const COLOR_MODES: FanColorMode[] = ['sex', 'generation', 'country', 'mono']
 const FONT_CATS: FontCategory[] = ['sans', 'serif', 'script', 'display']
 
 /** Compact popover with the fan-chart's look settings (sweep, colours, years). */
@@ -41,7 +41,7 @@ export function FanOptions(): JSX.Element {
       {open && (
         <>
           <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
-          <div className="glass-strong absolute left-0 top-10 z-50 w-60 space-y-3 rounded-2xl p-3 text-card-foreground">
+          <div className="glass-strong absolute left-0 top-10 z-50 w-72 space-y-3 rounded-2xl p-3 text-card-foreground">
             {/* Sweep */}
             <Field label={t('tree.fanSweep')}>
               <Segmented
@@ -141,7 +141,7 @@ function Segmented<T extends string | number>({
         <button
           key={String(o.value)}
           onClick={() => onChange(o.value)}
-          className={`flex-1 rounded-lg px-2 py-1 text-xs font-medium transition-colors ${
+          className={`min-w-0 flex-1 rounded-lg px-1 py-1 text-[11px] font-medium transition-colors ${
             value === o.value
               ? 'bg-card text-foreground shadow-[inset_0_1px_0_hsl(var(--glass-highlight)/0.4)] ring-1 ring-primary/20'
               : 'text-muted-foreground hover:text-foreground'

--- a/src/renderer/src/components/tree/export/fan.ts
+++ b/src/renderer/src/components/tree/export/fan.ts
@@ -2,7 +2,8 @@
 // generation rings of ancestor wedges with curved labels, recentred into a
 // positive `0 0 size size` box so the poster wrapper can place it.
 import { arc as d3arc } from 'd3-shape'
-import type { Sex, TreeNodeDatum } from '@shared/types'
+import type { TreeNodeDatum } from '@shared/types'
+import { canonicalCountryName } from '@shared/placeNormalize'
 import { formatName } from '@/lib/utils'
 import { PRINT, esc, truncate, type ExportContent, type TreeSvg } from './svgKit'
 
@@ -22,9 +23,50 @@ function pointAt(r: number, a: number): [number, number] {
   return [r * Math.sin(a), -r * Math.cos(a)]
 }
 
-function fillFor(sex: Sex | undefined, gen: number): string {
-  const base = sex === 'F' ? [244, 114, 182] : sex === 'M' ? [45, 212, 191] : [148, 163, 184]
+const GEN_HUES = [212, 250, 286, 330, 8, 40, 158, 186]
+const COUNTRY_HUES = [168, 36, 212, 334, 78, 266, 16, 196, 118, 308, 46, 226, 356, 144]
+
+function hashText(text: string): number {
+  let h = 0
+  for (let i = 0; i < text.length; i++) h = (h * 31 + text.charCodeAt(i)) >>> 0
+  return h
+}
+
+function hexToRgb(hex: string): [number, number, number] | null {
+  const m = /^#?([0-9a-f]{6})$/i.exec(hex.trim())
+  if (!m) return null
+  const n = parseInt(m[1], 16)
+  return [(n >> 16) & 255, (n >> 8) & 255, n & 255]
+}
+
+function countryFromPlace(place: string | null | undefined): string | null {
+  const raw = place?.trim()
+  if (!raw) return null
+  const parts = raw.split(',').map((p) => p.trim()).filter(Boolean)
+  return canonicalCountryName(parts.at(-1))
+}
+
+function countryOf(datum: TreeNodeDatum): string | null {
+  return datum.country ?? countryFromPlace(datum.birthPlace) ?? countryFromPlace(datum.deathPlace)
+}
+
+function fillFor(datum: TreeNodeDatum, gen: number, content: ExportContent): string {
   const fade = Math.max(0.18, 0.5 - gen * 0.05)
+  if (content.fanColorMode === 'generation') {
+    const h = GEN_HUES[(gen - 1) % GEN_HUES.length]
+    return `hsla(${h},64%,56%,${fade})`
+  }
+  if (content.fanColorMode === 'country') {
+    const country = countryOf(datum)
+    if (!country) return `rgba(148,163,184,${Math.max(0.13, fade * 0.72)})`
+    const h = COUNTRY_HUES[hashText(country.toLowerCase()) % COUNTRY_HUES.length]
+    return `hsla(${h},68%,50%,${fade})`
+  }
+  if (content.fanColorMode === 'mono') {
+    const rgb = hexToRgb(content.accent) ?? [71, 85, 105]
+    return `rgba(${rgb[0]},${rgb[1]},${rgb[2]},${fade})`
+  }
+  const base = datum.sex === 'F' ? [244, 114, 182] : datum.sex === 'M' ? [45, 212, 191] : [148, 163, 184]
   return `rgba(${base[0]},${base[1]},${base[2]},${fade})`
 }
 
@@ -69,7 +111,7 @@ export function buildFanTreeSvg(
     const outer = R0 + w.gen * RING
     const d = arcGen({ inner, outer, a0: w.a0, a1: w.a1 }) ?? ''
     fills.push(
-      `<path d="${d}" fill="${fillFor(w.datum.sex, w.gen)}" stroke="#ffffff" stroke-width="1"/>`
+      `<path d="${d}" fill="${fillFor(w.datum, w.gen, content)}" stroke="#ffffff" stroke-width="1"/>`
     )
 
     // Curved text guides.

--- a/src/renderer/src/components/tree/export/svgKit.ts
+++ b/src/renderer/src/components/tree/export/svgKit.ts
@@ -2,6 +2,7 @@
 // tree. Everything here emits plain SVG strings (no DOM, no React) so the same
 // output can be written as a .svg file or rasterised to PDF by the main process.
 import type { Sex } from '@shared/types'
+import type { FanColorMode } from '@/store/usePedigreeSettings'
 
 /** Print-friendly palette: white paper, dark ink, soft sex tints. */
 export const PRINT = {
@@ -71,6 +72,8 @@ export interface ExportContent {
   border: string
   /** Fan chart: CSS font-family for the labels (undefined = poster default). */
   fanFontFamily?: string
+  /** Fan chart: wedge colour mode, matching the on-screen fan. */
+  fanColorMode?: FanColorMode
   /** Fan chart: an @font-face block (base64 woff2) embedded so the chosen font
    *  renders in the standalone export/PDF with no CDN or system dependency. */
   fanFontFaceCss?: string

--- a/src/renderer/src/i18n/locales/de.json
+++ b/src/renderer/src/i18n/locales/de.json
@@ -1135,6 +1135,7 @@
     "fanColors": "Farben",
     "fanColor_sex": "Geschlecht",
     "fanColor_generation": "Generation",
+    "fanColor_country": "Land",
     "fanColor_mono": "Einfarbig",
     "fanYears": "Jahre",
     "fanFont": "Schriftart",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1135,6 +1135,7 @@
     "fanColors": "Colors",
     "fanColor_sex": "Sex",
     "fanColor_generation": "Generation",
+    "fanColor_country": "Country",
     "fanColor_mono": "Mono",
     "fanYears": "Years",
     "fanFont": "Font",

--- a/src/renderer/src/i18n/locales/hu.json
+++ b/src/renderer/src/i18n/locales/hu.json
@@ -1135,6 +1135,7 @@
     "fanColors": "Színek",
     "fanColor_sex": "Nem",
     "fanColor_generation": "Generáció",
+    "fanColor_country": "Ország",
     "fanColor_mono": "Egyszínű",
     "fanYears": "Évszámok",
     "fanFont": "Betűtípus",

--- a/src/renderer/src/store/usePedigreeSettings.ts
+++ b/src/renderer/src/store/usePedigreeSettings.ts
@@ -62,7 +62,7 @@ export type TreeViewKind = 'landscape' | 'portrait' | 'fan' | 'descendants'
 /** Fan chart sweep (degrees): full wheel, three-quarter, or classic semicircle. */
 export type FanSweep = 360 | 270 | 180
 /** Fan wedge colouring. */
-export type FanColorMode = 'sex' | 'generation' | 'mono'
+export type FanColorMode = 'sex' | 'generation' | 'country' | 'mono'
 /** Card-tree name label emphasis — opt-in, for readability when zoomed out. */
 export type LabelStrength = 'normal' | 'bold' | 'strong'
 

--- a/src/shared/placeNormalize.ts
+++ b/src/shared/placeNormalize.ts
@@ -1,0 +1,88 @@
+import { APP_LANGUAGES } from './languages'
+
+const fold = (value: string): string =>
+  value
+    .trim()
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[’']/g, "'")
+    .replace(/\s+/g, ' ')
+
+// ISO 3166-1 alpha-2 regions. Intl.DisplayNames supplies the canonical English
+// label and localized aliases, so adding a country never means adding a
+// one-off spelling to this module.
+const REGION_CODES = `
+AD AE AF AG AI AL AM AO AQ AR AS AT AU AW AX AZ
+BA BB BD BE BF BG BH BI BJ BL BM BN BO BQ BR BS BT BV BW BY BZ
+CA CC CD CF CG CH CI CK CL CM CN CO CR CU CV CW CX CY CZ
+DE DJ DK DM DO DZ EC EE EG EH ER ES ET FI FJ FK FM FO FR
+GA GB GD GE GF GG GH GI GL GM GN GP GQ GR GS GT GU GW GY
+HK HM HN HR HT HU ID IE IL IM IN IO IQ IR IS IT JE JM JO JP
+KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR LS LT LU LV LY
+MA MC MD ME MF MG MH MK ML MM MN MO MP MQ MR MS MT MU MV MW MX MY MZ
+NA NC NE NF NG NI NL NO NP NR NU NZ OM PA PE PF PG PH PK PL PM PN PR PS PT
+PW PY QA RE RO RS RU RW SA SB SC SD SE SG SH SI SJ SK SL SM SN SO SR SS ST
+SV SX SY SZ TC TD TF TG TH TJ TK TL TM TN TO TR TT TV TW TZ UA UG UM US UY UZ
+VA VC VE VG VI VN VU WF WS XK YE YT ZA ZM ZW
+`.trim().split(/\s+/)
+
+const COUNTRY_LOCALES = ['en', ...APP_LANGUAGES.filter((lang) => lang !== 'en')]
+
+function buildCountryAliases(): Map<string, string> {
+  const aliases = new Map<string, string>()
+  const displays = COUNTRY_LOCALES.map((locale) => new Intl.DisplayNames([locale], { type: 'region' }))
+
+  const add = (label: string | undefined, canonical: string): void => {
+    if (!label) return
+    const key = fold(label)
+    const existing = aliases.get(key)
+    // A localized label can be ambiguous (notably Congo). Keep ambiguous labels
+    // unresolved instead of silently assigning them to the wrong country.
+    if (existing && existing !== canonical) {
+      aliases.delete(key)
+      return
+    }
+    aliases.set(key, canonical)
+  }
+
+  for (const code of REGION_CODES) {
+    const canonical = displays[0].of(code)
+    if (!canonical) continue
+    add(canonical, canonical)
+    for (const display of displays.slice(1)) add(display.of(code), canonical)
+  }
+  return aliases
+}
+
+const COUNTRY_ALIASES = buildCountryAliases()
+
+export function canonicalCountryName(country: string | null | undefined): string | null {
+  const raw = country?.trim()
+  if (!raw) return null
+  return COUNTRY_ALIASES.get(fold(raw)) ?? raw
+}
+
+export function knownCountryAlias(country: string | null | undefined): string | null {
+  const raw = country?.trim()
+  if (!raw) return null
+  return COUNTRY_ALIASES.get(fold(raw)) ?? null
+}
+
+export function lastPlacePart(place: string | null | undefined): string | null {
+  const raw = place?.trim()
+  if (!raw) return null
+  const parts = raw.split(',').map((p) => p.trim()).filter(Boolean)
+  return parts.at(-1) ?? null
+}
+
+export function canonicalizeCountryInPlace(place: string | null | undefined): string {
+  const raw = place?.trim()
+  if (!raw) return ''
+  const parts = raw.split(',').map((p) => p.trim()).filter(Boolean)
+  if (parts.length === 0) return raw
+  const country = canonicalCountryName(parts.at(-1))
+  if (!country) return raw
+  parts[parts.length - 1] = country
+  return parts.join(', ')
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -228,6 +228,10 @@ export interface TreeNodeDatum {
   sex?: Sex
   birthYear?: string
   deathYear?: string
+  birthPlace?: string | null
+  deathPlace?: string | null
+  /** Canonical country for fan-chart colouring, derived from birth place first, then death place. */
+  country?: string | null
   __rd3t?: unknown
   children?: TreeNodeDatum[]
 }


### PR DESCRIPTION
## Summary

Add an optional Country color mode to the FanChart. Wedges use a stable hue derived from the canonical country, and the same mode is supported by printable/exported fan charts. Hover details include the country when available.

The chart consumes the shared canonical-country projection so localized country names remain grouped consistently.

## Related issue

Depends on #12 for the general country-normalization behavior.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / cleanup
- [ ] Docs / translations
- [ ] Build / tooling

## How was this tested?

- npm run typecheck
- npm run test:run

## Checklist

- [x] npm run typecheck passes
- [x] npm run test:run passes
- [x] No cloud calls / telemetry added — the app stays local-first and private
- [x] Docs/translations updated if needed
- [x] I agree my contribution is licensed under the project's PolyForm Noncommercial License 1.0.0